### PR TITLE
UI/style fix

### DIFF
--- a/lib/ui/auth/login/login_page.dart
+++ b/lib/ui/auth/login/login_page.dart
@@ -47,7 +47,7 @@ class LoginPageStatus extends State<LoginPage> {
                             fontSize: 24,
                           ),
                         ),
-                        SizedBox(height: 40),
+                        SizedBox(height: 20),
                         LoginTextField(
                           labelText: l10n.loginEmailTitle,
                           hintText: l10n.loginEmailInputHint,
@@ -60,8 +60,8 @@ class LoginPageStatus extends State<LoginPage> {
                           inputType: TextInputType.visiblePassword,
                           isPassword: true,
                         ),
+                        SizedBox(height: 15,),
                         BottomButton(buttonText: l10n.loginTitle, pressedFunc: (){}),
-                        SizedBox(height: 15),
                         Row(
                           children: [
                             Spacer(),

--- a/lib/ui/auth/signup/common_signup_page.dart
+++ b/lib/ui/auth/signup/common_signup_page.dart
@@ -22,7 +22,7 @@ class _CommonSignupPageState extends State<CommonSignupPage> {
   void _submit() {
     if (_formKey.currentState!.validate()) {
       // 모든 유효성 통과
-      context.go('/auth/signup/completed');
+      context.push('/auth/signup/completed');
     }
   }
 
@@ -120,7 +120,7 @@ class _CommonSignupPageState extends State<CommonSignupPage> {
                           ),
                         ),
 
-                        SizedBox(width: 5),
+                        SizedBox(width: 10),
                         SizedBox(
                           height: 60,
                           width: 60,

--- a/lib/ui/auth/signup/seller_signup_page.dart
+++ b/lib/ui/auth/signup/seller_signup_page.dart
@@ -19,7 +19,7 @@ class _SellerSignupPageState extends State<SellerSignupPage> {
   void _submit() {
     if (_formKey.currentState!.validate()) {
       // 모든 유효성 통과
-      context.go('/auth/signup/common');
+      context.push('/auth/signup/common');
     }
   }
 

--- a/lib/ui/auth/signup/user_role_selection_page.dart
+++ b/lib/ui/auth/signup/user_role_selection_page.dart
@@ -54,7 +54,7 @@ class UserRoleSelectionPage extends StatelessWidget {
                     ),
                   ),
                   onTap: (){
-                    context.go('/auth/signup/common');
+                    context.push('/auth/signup/common');
                   },
                 ),
                 SizedBox(width: 20,),
@@ -81,7 +81,7 @@ class UserRoleSelectionPage extends StatelessWidget {
                     ),
                   ),
                   onTap: (){
-                    context.go('/auth/signup/seller');
+                    context.push('/auth/signup/seller');
                   },
                 ),
               ],

--- a/lib/ui/home/home.dart
+++ b/lib/ui/home/home.dart
@@ -105,6 +105,7 @@ class _HomePageState extends State<HomePage> {
           final storeItems = (snapshot.data?.$3.data ?? []).take(8).toList();
 
           return SingleChildScrollView(
+            padding: EdgeInsets.symmetric(horizontal: 24),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -122,15 +123,13 @@ class _HomePageState extends State<HomePage> {
 
                 _buildSectionHeader(title: l10n.home_RecommendedProducts),
                 const SizedBox(height: 12),
-                Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 24),
-                    child: ProductsNonScrollableGrid(productItems.take(4).toList())
-                ),
+                ProductsNonScrollableGrid(productItems.take(4).toList()),
                 const SizedBox(height: 32),
 
                 const SizedBox(height: 32),
                 _buildSectionHeaderAndMore(title: l10n.home_OngoingFunding),
                 ListView.builder(
+                  padding: EdgeInsets.symmetric(horizontal: 0),
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(),
                   itemCount: fundingItems.length,
@@ -148,35 +147,33 @@ class _HomePageState extends State<HomePage> {
                 const SizedBox(height: 32),
 
                 _buildSectionHeaderAndMore(title: l10n.home_BrandList),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 24),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const SizedBox(height: 24),
-                      GridView.builder(
-                        shrinkWrap: true,
-                        physics: const NeverScrollableScrollPhysics(),
-                        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                          crossAxisCount: 4,
-                          crossAxisSpacing: 12,
-                          childAspectRatio: 0.8,
-                        ),
-                        itemCount: storeItems.length,
-                        itemBuilder: (context, index) {
-                          final brand = storeItems[index];
-                          return BrandGridItem(
-                            imageUrl: 'https://image.utoimage.com/preview/cp872722/2022/12/202212008462_500.jpg',
-                            brandName: brand.name,
-                            onTap: () {
-                              print('${brand.name} 클릭됨, ID: ${brand.id}');
-                              context.push('/branddetail/${brand.id}');
-                            },
-                          );
-                        },
-                      )
-                    ],
-                  ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const SizedBox(height: 24),
+                    GridView.builder(
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 4,
+                        crossAxisSpacing: 12,
+                        childAspectRatio: 0.8,
+                      ),
+                      itemCount: storeItems.length,
+                      itemBuilder: (context, index) {
+                        final brand = storeItems[index];
+                        return BrandGridItem(
+                          imageUrl: 'https://image.utoimage.com/preview/cp872722/2022/12/202212008462_500.jpg',
+                          brandName: brand.name,
+                          onTap: () {
+                            print('${brand.name} 클릭됨, ID: ${brand.id}');
+                            context.push('/branddetail/${brand.id}');
+                          },
+                        );
+                      },
+                    ),
+                    SizedBox(height: 20,)
+                  ],
                 ),
               ],
             ),
@@ -187,44 +184,39 @@ class _HomePageState extends State<HomePage> {
   }
 
   Widget _buildSectionHeader({required String title}) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 24),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(title, style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold)),
-        ],
-      ),
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(title, style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold)),
+      ],
     );
   }
 
   Widget _buildSectionHeaderAndMore({required String title}) {
 
-    return Padding(padding: const EdgeInsets.symmetric(horizontal: 24),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(
-            title,
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          title,
+          style: TextStyle(
+            fontSize: 22,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        Spacer(),
+        TextButton(
+          onPressed: (){},
+          child: Text(
+            "더보기",
             style: TextStyle(
-              fontSize: 22,
-              fontWeight: FontWeight.bold,
+                fontSize: 16,
+                color: AppColors.grey,
+                decoration: TextDecoration.underline
             ),
           ),
-          Spacer(),
-          TextButton(
-            onPressed: (){},
-            child: Text(
-              "더보기",
-              style: TextStyle(
-                  fontSize: 16,
-                  color: AppColors.grey,
-                  decoration: TextDecoration.underline
-              ),
-            ),
-          ),
-        ],
-      )
+        ),
+      ],
     );
   }
 }

--- a/lib/ui/mypage/change-password.dart
+++ b/lib/ui/mypage/change-password.dart
@@ -94,6 +94,7 @@ class _PasswordEditPageState extends State<PasswordEditPage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _buildLabel('현재 비밀번호'),
+            const SizedBox(height: 5,),
             _buildPasswordField(currentPasswordController, _obscureCurrent, () {
               setState(() {
                 _obscureCurrent = !_obscureCurrent;
@@ -101,9 +102,10 @@ class _PasswordEditPageState extends State<PasswordEditPage> {
               });
             }),
 
-            const SizedBox(height: 24),
+            const SizedBox(height: 20),
 
             _buildLabel('새 비밀번호'),
+            const SizedBox(height: 5,),
             _buildPasswordField(newPasswordController, _obscureNew, () {
               setState(() {
                 _obscureNew = !_obscureNew;
@@ -111,9 +113,10 @@ class _PasswordEditPageState extends State<PasswordEditPage> {
               });
             }),
 
-            const SizedBox(height: 24),
+            const SizedBox(height: 20),
 
             _buildLabel('비밀번호 확인'),
+            const SizedBox(height: 5,),
             _buildPasswordField(confirmPasswordController, _obscureConfirm, () {
               setState(() {
                 _obscureConfirm = !_obscureConfirm;
@@ -130,7 +133,7 @@ class _PasswordEditPageState extends State<PasswordEditPage> {
                 ),
               ),
 
-            const SizedBox(height: 32),
+            const SizedBox(height: 30),
 
             BottomButton(
               buttonText: '비밀번호 변경',

--- a/lib/ui/mypage/editprofile/editprofile.dart
+++ b/lib/ui/mypage/editprofile/editprofile.dart
@@ -68,22 +68,24 @@ class _EditProfilePageState extends State<EditProfilePage> {
         elevation: 0,
       ),
       body: SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
         child: Form(
           key: _formKey,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               _buildLabel('닉네임'),
+              const SizedBox(height: 5,),
               _buildTextFormField(_nicknameController, validatorText: '닉네임을 입력해주세요'),
 
               const SizedBox(height: 16),
               _buildLabel('성함'),
+              const SizedBox(height: 5,),
               _buildTextFormField(_nameController, validatorText: '성함을 입력해주세요'),
 
               const SizedBox(height: 16),
               _buildLabel('성별'),
-              const SizedBox(height: 8),
+              const SizedBox(height: 5),
               CustomDropdown(
                 selectedValue: _selectedGender,
                 items: ['여성', '남성', '선택하지않음'],
@@ -96,6 +98,7 @@ class _EditProfilePageState extends State<EditProfilePage> {
 
               const SizedBox(height: 16),
               _buildLabel('전화번호'),
+              const SizedBox(height: 5,),
               _buildTextFormField(
                 _phoneController,
                 keyboardType: TextInputType.phone,
@@ -104,6 +107,7 @@ class _EditProfilePageState extends State<EditProfilePage> {
 
               const SizedBox(height: 16),
               _buildLabel('우편번호'),
+              const SizedBox(height: 5,),
               _buildTextFormField(
                 _zipcodeController,
                 keyboardType: TextInputType.number,
@@ -120,10 +124,12 @@ class _EditProfilePageState extends State<EditProfilePage> {
 
               const SizedBox(height: 16),
               _buildLabel('주소'),
+              const SizedBox(height: 5,),
               _buildTextFormField(_addressController, validatorText: '주소를 입력해주세요'),
 
               const SizedBox(height: 16),
               _buildLabel('상세주소'),
+              const SizedBox(height: 5,),
               _buildTextFormField(_detailAddressController, validatorText: '상세주소를 입력해주세요'),
 
               const SizedBox(height: 32),
@@ -168,7 +174,7 @@ class _EditProfilePageState extends State<EditProfilePage> {
           keyboardType: keyboardType,
           style: const TextStyle(
             fontWeight: FontWeight.w600,
-            fontSize: 20,
+            fontSize: 16,
             color: Colors.black,
           ),
           decoration: InputDecoration(

--- a/lib/ui/mypage/mypage.dart
+++ b/lib/ui/mypage/mypage.dart
@@ -30,7 +30,7 @@ class MyPage extends StatelessWidget {
         ],
       ),
       body: Padding(
-        padding: const EdgeInsets.all(16.0),
+        padding: const EdgeInsets.symmetric(horizontal: 24.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -92,19 +92,19 @@ class MyPage extends StatelessWidget {
               ],
             ),
 
-            const SizedBox(height: 16),
+            const SizedBox(height: 20),
 
             // 쇼핑 섹션 라벨
             const Text(
               '쇼핑',
               style: TextStyle(
                 fontWeight: FontWeight.w400,
-                fontSize: 13,
+                fontSize: 16,
                 color: AppColors.grey,
               ),
             ),
 
-            const SizedBox(height: 12),
+            const SizedBox(height: 10),
 
             // 주문 내역
             ListTile(
@@ -113,12 +113,12 @@ class MyPage extends StatelessWidget {
               title: const Text(
                 '주문 내역',
                 style: TextStyle(
-                  fontSize: 13,
+                  fontSize: 16,
                   fontWeight: FontWeight.w600,
                   color: Colors.black,
                 ),
               ),
-              trailing: const Icon(Icons.chevron_right, size: 16, color: Colors.black),
+              trailing: const Icon(Icons.chevron_right, size: 20, color: Colors.black),
               onTap: () {
                 context.push('/orderlist');
               },
@@ -131,12 +131,12 @@ class MyPage extends StatelessWidget {
               title: const Text(
                 '위시리스트',
                 style: TextStyle(
-                  fontSize: 13,
+                  fontSize: 16,
                   fontWeight: FontWeight.w600,
                   color: Colors.black,
                 ),
               ),
-              trailing: const Icon(Icons.chevron_right, size: 16, color: Colors.black),
+              trailing: const Icon(Icons.chevron_right, size: 20, color: Colors.black),
               onTap: () {
                 context.push('/wish');
               },
@@ -146,20 +146,21 @@ class MyPage extends StatelessWidget {
             const Divider(
               color: AppColors.DividerTextBoxLineDivider,
               thickness: 1,
-              height: 16,
+              height: 20,
             ),
 
             // 내 정보 섹션 라벨
+            const SizedBox(height: 10,),
             const Text(
               '내 정보',
               style: TextStyle(
                 fontWeight: FontWeight.w400,
-                fontSize: 13,
+                fontSize: 16,
                 color: AppColors.grey,
               ),
             ),
 
-            const SizedBox(height: 12),
+            const SizedBox(height: 10),
 
             // 비밀번호 변경
             ListTile(
@@ -168,12 +169,12 @@ class MyPage extends StatelessWidget {
               title: const Text(
                 '비밀번호 변경',
                 style: TextStyle(
-                  fontSize: 13,
+                  fontSize: 16,
                   fontWeight: FontWeight.w600,
                   color: Colors.black,
                 ),
               ),
-              trailing: const Icon(Icons.chevron_right, size: 16, color: Colors.black),
+              trailing: const Icon(Icons.chevron_right, size: 20, color: Colors.black),
               onTap: () {
                 context.push('/mypage/password');
               },
@@ -183,7 +184,7 @@ class MyPage extends StatelessWidget {
             const Divider(
               color: AppColors.DividerTextBoxLineDivider,
               thickness: 1,
-              height: 16,
+              height: 20,
             ),
           ],
         ),

--- a/lib/ui/mypage_seller/add_funding.dart
+++ b/lib/ui/mypage_seller/add_funding.dart
@@ -45,7 +45,7 @@ class _FundingRegisterPageState extends State<FundingRegisterPage> {
       ),
       backgroundColor: Colors.white,
       body: SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -70,7 +70,7 @@ class _FundingRegisterPageState extends State<FundingRegisterPage> {
 
       bottomNavigationBar: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.all(16.0),
+          padding: const EdgeInsets.all(24.0),
           child: BottomButton(
             buttonText: '펀딩 추가',
             pressedFunc: () {},
@@ -85,7 +85,7 @@ class _FundingRegisterPageState extends State<FundingRegisterPage> {
       title,
       style: const TextStyle(
         fontWeight: FontWeight.w600,
-        fontSize: 16,
+        fontSize: 20,
         color: Colors.black,
       ),
     );

--- a/lib/ui/mypage_seller/add_product.dart
+++ b/lib/ui/mypage_seller/add_product.dart
@@ -77,7 +77,7 @@ class _ProductRegisterPageState extends State<ProductRegisterPage> {
       ),
       backgroundColor: Colors.white,
       body: SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -165,7 +165,7 @@ class _ProductRegisterPageState extends State<ProductRegisterPage> {
       title,
       style: const TextStyle(
         fontWeight: FontWeight.w600,
-        fontSize: 16,
+        fontSize: 20,
         color: Colors.black,
       ),
     );

--- a/lib/ui/mypage_seller/edit_brand.dart
+++ b/lib/ui/mypage_seller/edit_brand.dart
@@ -46,7 +46,7 @@ class _BrandEditPageState extends State<BrandEditPage> {
       ),
       backgroundColor: Colors.white,
       body: SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -70,7 +70,7 @@ class _BrandEditPageState extends State<BrandEditPage> {
 
       bottomNavigationBar: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.all(16.0),
+          padding: const EdgeInsets.all(24.0),
           child: BottomButton(
             buttonText: '저장',
             pressedFunc: () {
@@ -87,7 +87,7 @@ class _BrandEditPageState extends State<BrandEditPage> {
       title,
       style: const TextStyle(
         fontWeight: FontWeight.w600,
-        fontSize: 16,
+        fontSize: 20,
         color: Colors.black,
       ),
     );

--- a/lib/ui/mypage_seller/editprofile/edit_profile_seller.dart
+++ b/lib/ui/mypage_seller/editprofile/edit_profile_seller.dart
@@ -68,17 +68,19 @@ class _EditProfileSellerPageState extends State<EditProfileSellerPage> {
         elevation: 0,
       ),
       body: SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
         child: Form(
           key: _formKey,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               _buildLabel('담당자명'),
+              const SizedBox(height: 5,),
               _buildTextFormField(_managerController, validatorText: '담당자명을 입력해주세요'),
 
               const SizedBox(height: 16),
               _buildLabel('전화번호'),
+              const SizedBox(height: 5,),
               _buildTextFormField(
                 _phoneController,
                 keyboardType: TextInputType.phone,
@@ -87,6 +89,7 @@ class _EditProfileSellerPageState extends State<EditProfileSellerPage> {
 
               const SizedBox(height: 16),
               _buildLabel('우편번호'),
+              const SizedBox(height: 5,),
               _buildTextFormField(
                 _zipcodeController,
                 keyboardType: TextInputType.number,
@@ -103,13 +106,15 @@ class _EditProfileSellerPageState extends State<EditProfileSellerPage> {
 
               const SizedBox(height: 16),
               _buildLabel('주소'),
+              const SizedBox(height: 5,),
               _buildTextFormField(_addressController, validatorText: '주소를 입력해주세요'),
 
               const SizedBox(height: 16),
               _buildLabel('상세주소'),
+              const SizedBox(height: 5,),
               _buildTextFormField(_detailAddressController, validatorText: '상세주소를 입력해주세요'),
 
-              const SizedBox(height: 32),
+              const SizedBox(height: 30),
             ],
           ),
         ),
@@ -151,7 +156,7 @@ class _EditProfileSellerPageState extends State<EditProfileSellerPage> {
           keyboardType: keyboardType,
           style: const TextStyle(
             fontWeight: FontWeight.w600,
-            fontSize: 20,
+            fontSize: 16,
             color: Colors.black,
           ),
           decoration: InputDecoration(

--- a/lib/ui/mypage_seller/mypage_seller.dart
+++ b/lib/ui/mypage_seller/mypage_seller.dart
@@ -25,7 +25,7 @@ class SellerMyPage extends StatelessWidget {
         ),
       ),
       body: Padding(
-        padding: const EdgeInsets.all(16.0),
+        padding: const EdgeInsets.symmetric(horizontal: 24.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -46,7 +46,7 @@ class SellerMyPage extends StatelessWidget {
                       ),
                       child: const Icon(Icons.person, color: Colors.pink),
                     ),
-                    const SizedBox(width: 12),
+                    const SizedBox(width: 10),
                     Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
@@ -98,19 +98,19 @@ class SellerMyPage extends StatelessWidget {
               ],
             ),
 
-            const SizedBox(height: 16),
+            const SizedBox(height: 20),
 
             // 주문 섹션 라벨
             const Text(
               '주문',
               style: TextStyle(
                 fontWeight: FontWeight.w400,
-                fontSize: 13,
+                fontSize: 16,
                 color: AppColors.grey,
               ),
             ),
 
-            const SizedBox(height: 12),
+            const SizedBox(height: 10),
 
             // 주문 내역
             ListTile(
@@ -119,12 +119,12 @@ class SellerMyPage extends StatelessWidget {
               title: const Text(
                 '주문 내역',
                 style: TextStyle(
-                  fontSize: 13,
+                  fontSize: 16,
                   fontWeight: FontWeight.w600,
                   color: Colors.black,
                 ),
               ),
-              trailing: const Icon(Icons.chevron_right, size: 16, color: Colors.black),
+              trailing: const Icon(Icons.chevron_right, size: 20, color: Colors.black),
               onTap: () {},
             ),
 
@@ -132,20 +132,21 @@ class SellerMyPage extends StatelessWidget {
             const Divider(
               color: AppColors.DividerTextBoxLineDivider,
               thickness: 1,
-              height: 16,
+              height: 20,
             ),
 
             // 마이페이지 섹션 라벨
+            const SizedBox(height: 10,),
             const Text(
               '마이페이지',
               style: TextStyle(
                 fontWeight: FontWeight.w400,
-                fontSize: 13,
+                fontSize: 16,
                 color: AppColors.grey,
               ),
             ),
 
-            const SizedBox(height: 12),
+            const SizedBox(height: 10),
 
             // 프로필 수정
             ListTile(
@@ -154,12 +155,12 @@ class SellerMyPage extends StatelessWidget {
               title: const Text(
                 '프로필 수정',
                 style: TextStyle(
-                  fontSize: 13,
+                  fontSize: 16,
                   fontWeight: FontWeight.w600,
                   color: Colors.black,
                 ),
               ),
-              trailing: const Icon(Icons.chevron_right, size: 16, color: Colors.black),
+              trailing: const Icon(Icons.chevron_right, size: 20, color: Colors.black),
               onTap: () {
                 context.go('/mypage/edit-seller');
               },
@@ -172,12 +173,12 @@ class SellerMyPage extends StatelessWidget {
               title: const Text(
                 '비밀번호 변경',
                 style: TextStyle(
-                  fontSize: 13,
+                  fontSize: 16,
                   fontWeight: FontWeight.w600,
                   color: Colors.black,
                 ),
               ),
-              trailing: const Icon(Icons.chevron_right, size: 16, color: Colors.black),
+              trailing: const Icon(Icons.chevron_right, size: 20, color: Colors.black),
               onTap: () {
                 context.go('/mypage/password');
               },
@@ -190,12 +191,12 @@ class SellerMyPage extends StatelessWidget {
               title: const Text(
                 '상품 등록',
                 style: TextStyle(
-                  fontSize: 13,
+                  fontSize: 16,
                   fontWeight: FontWeight.w600,
                   color: Colors.black,
                 ),
               ),
-              trailing: const Icon(Icons.chevron_right, size: 16, color: Colors.black),
+              trailing: const Icon(Icons.chevron_right, size: 20, color: Colors.black),
               onTap: () {
                 context.go('/mypage/register');
               },
@@ -208,12 +209,12 @@ class SellerMyPage extends StatelessWidget {
               title: const Text(
                 '펀딩 등록',
                 style: TextStyle(
-                  fontSize: 13,
+                  fontSize: 16,
                   fontWeight: FontWeight.w600,
                   color: Colors.black,
                 ),
               ),
-              trailing: const Icon(Icons.chevron_right, size: 16, color: Colors.black),
+              trailing: const Icon(Icons.chevron_right, size: 20, color: Colors.black),
               onTap: () {
                 context.push('/funding/register');
               },
@@ -227,12 +228,12 @@ class SellerMyPage extends StatelessWidget {
               title: const Text(
                 '등록 상품 / 펀딩 관리',
                 style: TextStyle(
-                  fontSize: 13,
+                  fontSize: 16,
                   fontWeight: FontWeight.w600,
                   color: Colors.black,
                 ),
               ),
-              trailing: const Icon(Icons.chevron_right, size: 16, color: Colors.black),
+              trailing: const Icon(Icons.chevron_right, size: 20, color: Colors.black),
               onTap: () {
                 context.push('/brand/editproduct');
               },

--- a/lib/ui/order/order_detail_page.dart
+++ b/lib/ui/order/order_detail_page.dart
@@ -25,8 +25,7 @@ class OrderDetailPage extends StatelessWidget {
                 orderDate: "2025-00-00",
                 userName: "김이박",
               ),
-              SizedBox(height: 10),
-              Divider(color: Color(0xFFC9C9C9)),
+              Divider(color: Colors.black, height: 30.0,),
               Text(
                 "주문 상품",
                 style: TextStyle(
@@ -35,7 +34,7 @@ class OrderDetailPage extends StatelessWidget {
                   fontSize: 20,
                 ),
               ),
-              SizedBox(height: 15),
+              SizedBox(height: 10),
               ListView.separated(
                 itemCount: 4,
                 shrinkWrap: true,
@@ -51,10 +50,10 @@ class OrderDetailPage extends StatelessWidget {
                   );
                 },
                 separatorBuilder: (BuildContext context, int index) =>
-                    const Divider(color: Color(0xFFC9C9C9)),
+                    const Divider(color: AppColors.DividerTextBoxLineDivider, height: 20.0,),
               ),
-              SizedBox(height: 10),
-              Divider(color: Color(0xFFC9C9C9)),
+              SizedBox(height: 10,),
+              Divider(color: Colors.black, height: 30.0,),
               Text(
                 "결제 정보",
                 style: TextStyle(
@@ -65,8 +64,8 @@ class OrderDetailPage extends StatelessWidget {
               ),
               SizedBox(height: 15),
               PriceInfoBox(price: 16800, shippingFee: 0, totalPrice: 16800),
-              SizedBox(height: 20),
-              Divider(color: Color(0xFFC9C9C9)),
+              SizedBox(height: 10),
+              Divider(color: Colors.black, height: 30.0,),
               Text(
                 "배송지 정보",
                 style: TextStyle(

--- a/lib/ui/order/order_list.dart
+++ b/lib/ui/order/order_list.dart
@@ -41,34 +41,41 @@ class OrderListPage extends StatelessWidget {
         surfaceTintColor: Colors.white,
       ),
       backgroundColor: Colors.white,
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 8.0),
-            child: Text(
+      body: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Padding(
+            //   padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 8.0),
+            //   child:
+            // ),
+            Text(
               '총 주문 내역 ${_dummyOrders.length}개',
               style: const TextStyle(fontSize: 14, color: Colors.grey),
             ),
-          ),
-          // 주문 목록
-          Expanded(
-            child: ListView.builder(
-              itemCount: _dummyOrders.length,
-              itemBuilder: (context, index) {
-                final order = _dummyOrders[index];
-                return OrderListItem(
-                  orderNumber: order['orderNumber'],
-                  orderDate: order['orderDate'],
-                  totalAmount: order['totalAmount'],
-                  status: order['status'],
-                  products: List<String>.from(order['products']),
-                );
-              },
+            SizedBox(height: 10,),
+            Divider(color: Colors.black, height: 1.0,),
+            // 주문 목록
+            Expanded(
+              child: ListView.builder(
+                padding: EdgeInsets.zero,
+                itemCount: _dummyOrders.length,
+                itemBuilder: (context, index) {
+                  final order = _dummyOrders[index];
+                  return OrderListItem(
+                    orderNumber: order['orderNumber'],
+                    orderDate: order['orderDate'],
+                    totalAmount: order['totalAmount'],
+                    status: order['status'],
+                    products: List<String>.from(order['products']),
+                  );
+                },
+              ),
             ),
-          ),
-        ],
-      ),
+          ],
+        ),
+      )
     );
   }
 }

--- a/lib/ui/products/products_detail.dart
+++ b/lib/ui/products/products_detail.dart
@@ -287,7 +287,7 @@ class ProductsNameSection extends StatelessWidget {
     bool hasDiscount = false;
     int finalPrice = product.price;
 
-    if (product.discount != null && product.discount!.isNotEmpty) {
+    if (product.discount != null && product.discount! != 0) {
       try {
         final discountData = jsonDecode(product.discount!);
         rate = discountData['value'];

--- a/lib/ui/products/products_detail.dart
+++ b/lib/ui/products/products_detail.dart
@@ -25,13 +25,7 @@ class ProductsDetailPage extends StatelessWidget {
           }, icon: const Icon(Icons.shopping_bag_outlined))
         ],
       ),
-      body: Row(
-        children: [
-          const SizedBox(width: 24),
-          Expanded(child: ProductsDetailScreen(productId)),
-          const SizedBox(width: 24),
-        ],
-      ),
+      body: ProductsDetailScreen(productId),
     );
   }
 }
@@ -53,12 +47,16 @@ class _ProductsDetailScreenState extends State<ProductsDetailScreen> {
   int quantity = 1;
   String? selectedColor;
   String? selectedSize;
-  bool isFavorite = false;
+  late bool isFavorite;
 
   @override
   void initState() {
     super.initState();
-    _productsFuture = apiClient.productDetail(widget.id);
+    _productsFuture = apiClient.productDetail(widget.id).then((response) {
+      final data = response.data;
+      isFavorite = data?.isFavorite ?? false;
+      return response;
+    });
   }
 
   void _toggleFavorite() {
@@ -86,8 +84,6 @@ class _ProductsDetailScreenState extends State<ProductsDetailScreen> {
 
         final product = snapshot.data!.data!;
 
-        isFavorite = product.isFavorite;
-
         // 옵션 응답이 다 달라서 더미로 대체
         // final sizeOptions = product.options?.size ?? [];
         // final colorOptions = product.options?.color ?? [];
@@ -100,6 +96,7 @@ class _ProductsDetailScreenState extends State<ProductsDetailScreen> {
         const placeholderImage = 'https://via.placeholder.com/400';
 
         return ListView(
+          padding: EdgeInsets.symmetric(horizontal: 24),
           children: [
             AspectRatio(
               aspectRatio: 1,
@@ -137,11 +134,11 @@ class _ProductsDetailScreenState extends State<ProductsDetailScreen> {
               ],
             ),
             const Divider(color: Colors.black),
-            const SizedBox(height: 20),
+            const SizedBox(height: 5),
 
             // --- 상품 상세 이미지 ---
             ProductsDetailImageSection(product.images?.detail ?? []),
-            const SizedBox(height: 20),
+            const SizedBox(height: 5),
             const Divider(color: Colors.black),
 
             // --- 옵션 선택 ---

--- a/lib/ui/products/products_list.dart
+++ b/lib/ui/products/products_list.dart
@@ -18,7 +18,7 @@ class ProductsListPage extends StatelessWidget {
           centerTitle: true,
           title: Text(
             categoryId ?? l10n!.appTitle,
-            style: TextStyle(
+            style: const TextStyle(
                 fontWeight: FontWeight.bold,
                 fontSize: 24),
           ),
@@ -27,11 +27,14 @@ class ProductsListPage extends StatelessWidget {
                 onPressed: (){
                   context.push('/wish/cart');
                 },
-                icon: Icon(Icons.shopping_bag_outlined)
+                icon: const Icon(Icons.shopping_bag_outlined)
             )
           ],
         ),
-        body: ProductsListScreen()
+        body: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 24),
+          child: ProductsListScreen(),
+        )
     );
   }
 }
@@ -60,13 +63,7 @@ class ProductsListScreen extends StatelessWidget {
         }
 
         final data = snapshot.data?.data?.items ?? [];
-        return Row(
-          children: [
-            SizedBox(width: 24,),
-            Expanded(child: ProductsDoubleGrid(data),),
-            SizedBox(width: 24,)
-          ],
-        );
+        return ProductsDoubleGrid(data);
       },
     );
   }

--- a/lib/ui/wish/wish.dart
+++ b/lib/ui/wish/wish.dart
@@ -81,19 +81,25 @@ class WishPageState extends State<WishPage> {
             );
           }).toList();
 
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              CategoryHorizontalScroll(),
-              ListToolbar(productList.length),
-              Expanded(
-                child: productList.isEmpty
-                    ? const Center(child: Text('위시리스트에 추가된 상품이 없습니다.'))
-                    : ProductsDoubleGrid(
-                  productList,
+          return Padding(
+            padding: EdgeInsets.symmetric(horizontal: 24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                CategoryHorizontalScroll(),
+                ListToolbar(productList.length),
+                Expanded(
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 24),
+                      child: productList.isEmpty
+                          ? const Center(child: Text('위시리스트에 추가된 상품이 없습니다.'))
+                          : ProductsDoubleGrid(
+                        productList,
+                      ),
+                    )
                 ),
-              ),
-            ],
+              ],
+            ),
           );
         },
       ),

--- a/lib/widgets/cart_list_item.dart
+++ b/lib/widgets/cart_list_item.dart
@@ -56,7 +56,7 @@ class CartListItemState extends State<CartListItem> {
             ),
           ],
         ),
-        const SizedBox(height: 10),
+        const SizedBox(height: 5),
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -136,6 +136,7 @@ class CartListItemState extends State<CartListItem> {
                       ],
                     ),
                   ),
+                  SizedBox(height: 10,)
                 ],
               ),
             ),

--- a/lib/widgets/funding_list_item.dart
+++ b/lib/widgets/funding_list_item.dart
@@ -27,6 +27,7 @@ class FundingListItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
+      contentPadding: EdgeInsets.symmetric(horizontal: 0),
       leading: ClipRRect(
         borderRadius: BorderRadius.circular(8.0),
         child: SizedBox(
@@ -84,8 +85,6 @@ class FundingListItem extends StatelessWidget {
           ),
         ],
       ),
-      contentPadding:
-      const EdgeInsets.symmetric(horizontal: 24, vertical: 12.0),
       onTap: () {
         if (linkUrl.isNotEmpty) {
           _launchURL(linkUrl);

--- a/lib/widgets/list_toolbar.dart
+++ b/lib/widgets/list_toolbar.dart
@@ -8,7 +8,7 @@ class ListToolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: EdgeInsets.fromLTRB(24, 0, 24, 15),
+      margin: EdgeInsets.fromLTRB(0, 0, 0, 15),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [

--- a/lib/widgets/order_list_item.dart
+++ b/lib/widgets/order_list_item.dart
@@ -29,65 +29,61 @@ class OrderListItem extends StatelessWidget {
         context.push('/orderdetail');
       },
       child: Container(
-        padding: const EdgeInsets.symmetric(vertical: 20.0),
+        padding: EdgeInsets.symmetric(vertical: 10),
         decoration: const BoxDecoration(
           border: Border(
-            bottom: BorderSide(color: Color(0xFFEEEEEE), width: 1.0),
+            bottom: BorderSide(color: Colors.black, width: 1.0),
           ),
         ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                '주문번호 : $orderNumber',
-                style: const TextStyle(fontSize: 13, color: Colors.grey),
-              ),
-              const SizedBox(height: 16),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        orderDate,
-                        style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        '총 ${currencyFormat.format(totalAmount)}원',
-                        style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-                      ),
-                    ],
-                  ),
-                  const Spacer(),
-                  Text(
-                    '현재상태: $status',
-                    style: TextStyle(
-                      fontSize: 13,
-                      color: statusColor,
-                      fontWeight: FontWeight.bold,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '주문번호 : $orderNumber',
+              style: const TextStyle(fontSize: 13, color: Colors.grey),
+            ),
+            const SizedBox(height: 10),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      orderDate,
+                      style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                     ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: products.map((product) {
-                  return Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 4.0),
-                    child: Text(
-                      product,
-                      style: const TextStyle(fontSize: 14, color: Color(0xFF555555)),
+                    Text(
+                      '총 ${currencyFormat.format(totalAmount)}원',
+                      style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                     ),
-                  );
-                }).toList(),
-              ),
-            ],
-          ),
+                  ],
+                ),
+                const Spacer(),
+                Text(
+                  '현재상태: $status',
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: statusColor,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: products.map((product) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4.0),
+                  child: Text(
+                    product,
+                    style: const TextStyle(fontSize: 14, color: Color(0xFF555555)),
+                  ),
+                );
+              }).toList(),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
UI 확인이 끝났습니다. 주요 수정은 다음과 같습니다.
- 마이페이지 및 마이페이지에서 연결되는 관리 페이지들의 좌우 여백이 16이었던 것을 24로 변경
- 마이페이지 텍스트가 16이었던 것을 화면 명세에 따라 20으로 변경
- 화면 명세와 화면이 다르게 보이는 경우, 의도한 대로 보일 수 있도록 sizedbox 등의 크기를 변경
- 화면 전체의 padding을 일괄 24로 적용하고, 내부 위젯의 padding은 최대한 제거
- 화면 내부에서 쓰이는 위젯의 경우, 위젯 내부 padding을 제거하고 화면 전체의 padding으로 제어하도록 변경
- 주문 목록 페이지에서 리스트 내부 padding과 화면 전체의 padding이 중복 적용되어 list가 안으로 들어가 보이던 것을 변경
- divider의 쓰임에 따라, 일부 divider 색상을 회색에서 검정으로 변경
- divider의 높이를 조절
- 회원가입 페이지에서 뒤로 돌아갈 수 있도록 라우팅 수정 **이 부분은 한번 확인해주세요**

남은 것은 아래와 같습니다.
- 진입점이 없는 펀딩/상품 편집 페이지는 수정하지 못함
- 상품 리스트에서 favorite 등록/삭제/표시 기능의 경우 현재 Api 반영되지 않았고, 관련 기능도 없음
- 공통 회원가입 페이지에서 전체 값을 등록하지 않아 hint가 보인 경우, 이메일을 기입할 때 pixel overflow 발생함

중요하지 않은 것은 아래와 같습니다.
- 카테고리 필터링 버튼 횡스크롤 리스트의 경우, 내부에 padding이 있어 어디에 적용해도 약간 들어가 보임
- 카테고리 필터링 버튼 횡스크롤 리스트를 padding이 일괄 24로 적용된 화면에 넣으면 스크롤할 때 padding을 침범하지 않아 약간 잘린 듯한 느낌이 있음